### PR TITLE
Revert "Bump crazy-max/ghaction-github-labeler from 5.0.0 to 5.1.0"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,6 +15,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v5.1.0
+        uses: crazy-max/ghaction-github-labeler@v5.0.0
         with:
           skip-delete: true


### PR DESCRIPTION
Reverts amosyuen/ha-epson-projector-link#129 because of https://github.com/crazy-max/ghaction-github-labeler/issues/221