### PR TITLE
Add HDBaseT label compatiblity to Source

### DIFF
--- a/custom_components/epson_projector_link/projector/const.py
+++ b/custom_components/epson_projector_link/projector/const.py
@@ -189,6 +189,7 @@ SOURCE_CODE_MAP = {
     "52": "USB",
     "53": "LAN",
     "56": "WiFi Direct",
+    "80": "HDBaseT",
     "A0": "HDMI2",
     "D0": "WirelessHD",
 }


### PR DESCRIPTION
I have an EB-L630U projector that supports HDBaseT. I use it with a HDBaseT compatible HDMI Matrix. The source code is 80 but I'm wanting it to read as HDBaseT. I double checked and [ESCVP21 command guide for business projector Rev.G.xlsx](https://kb.epson.eu/webfiles/attachments/escvp_guide.zip) confirms it under the UST(Business) tab.

Confirmed as working with this code
![image](https://github.com/user-attachments/assets/3c08e2a9-fe29-439d-a7e6-b0ad31ff6257)
